### PR TITLE
Security: change default way how password is obtained

### DIFF
--- a/dtool_smb/__init__.py
+++ b/dtool_smb/__init__.py
@@ -1,4 +1,4 @@
-"""dtool_azure package."""
+"""dtool_smb package."""
 
 import logging
 

--- a/dtool_smb/storagebroker.py
+++ b/dtool_smb/storagebroker.py
@@ -619,7 +619,3 @@ class SMBStorageBroker(BaseStorageBroker):
                 key = os.path.join(self.path, shf.filename)
                 historical_readme_keys.append(key)
         return historical_readme_keys
-
-
-
-

--- a/dtool_smb/storagebroker.py
+++ b/dtool_smb/storagebroker.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import socket
+import getpass
 
 from base64 import b64encode
 
@@ -154,10 +155,6 @@ class SMBStorageBroker(BaseStorageBroker):
             "DTOOL_SMB_USERNAME_{}".format(config_name),
             config_path=config_path
         )
-        password = get_config_value(
-            "DTOOL_SMB_PASSWORD_{}".format(config_name),
-            config_path=config_path
-        )
         server_name = get_config_value(
             "DTOOL_SMB_SERVER_NAME_{}".format(config_name),
             config_path=config_path
@@ -182,10 +179,6 @@ class SMBStorageBroker(BaseStorageBroker):
         if not username:
             raise RuntimeError("No username specified for service '{name}', "
                                "please set DTOOL_SMB_USERNAME_{name}."
-                               .format(name=config_name))
-        if not password:
-            raise RuntimeError("No password specified for service '{name}', "
-                               "please set DTOOL_SMB_PASSWORD_{name}."
                                .format(name=config_name))
         if not server_name:
             raise RuntimeError("No server name specified for service '{name}', "
@@ -216,7 +209,7 @@ class SMBStorageBroker(BaseStorageBroker):
         server_ip = socket.gethostbyname(server_name)
         host_name = socket.gethostname()
 
-        conn = SMBConnection(username, password, host_name, server_name,
+        conn = SMBConnection(username, getpass.getpass(), host_name, server_name,
             domain=domain, use_ntlm_v2=True, is_direct_tcp=True)
 
         logger.info( ( "Connecting from '{host:s}' to "
@@ -228,15 +221,13 @@ class SMBStorageBroker(BaseStorageBroker):
 
         # for testing, see types of arguments
         logger.debug( ( "Types HOST '{host:s}', USER '{user:s}', IP '{ip:s}', "
-           "SERVER '{server:s}', PORT '{port:s}', DOMAIN '{domain:s}', "
-            "PASSWORD '{password:s}'").format(
+           "SERVER '{server:s}', PORT '{port:s}', DOMAIN '{domain:s}'").format(
                 user=type(username).__name__,
                 ip=type(server_ip).__name__,
                 server=type(server_name).__name__,
                 port=type(server_port).__name__,
                 host=type(host_name).__name__,
-                domain=type(domain).__name__,
-                password=type(password).__name__ ) )
+                domain=type(domain).__name__)
 
         conn.connect(server_ip, port=server_port)
 

--- a/dtool_smb/storagebroker.py
+++ b/dtool_smb/storagebroker.py
@@ -215,12 +215,16 @@ class SMBStorageBroker(BaseStorageBroker):
 
         server_ip = socket.gethostbyname(server_name)
         host_name = socket.gethostname()
-
-        if cls._connect.num_calls == 1:
-            password = getpass.getpass()
-            cls.password = password
-        else:
-            password = cls.password
+        password = get_config_value(
+            "DTOOL_SMB_PASSWORD_{}".format(config_name),
+            config_path=config_path
+        )
+        if password is None:
+            if cls._connect.num_calls == 1:
+                password = getpass.getpass()
+                cls.password = password
+            else:
+                password = cls.password
         conn = SMBConnection(username, password, host_name, server_name,
             domain=domain, use_ntlm_v2=True, is_direct_tcp=True)
 


### PR DESCRIPTION
This commit changes the way how the storage broker acquires the password for the SMB connection. Previously, the password was read from a json configuration file, i.e. it was stored in plain text. This is a security risk, so I have changed the default behaviour. The user is now queried for the password when
the connection is established for the first time. 